### PR TITLE
Revert "Hot fix for missing translation"

### DIFF
--- a/rest/src/asset.cpp
+++ b/rest/src/asset.cpp
@@ -22,7 +22,6 @@
 #include "asset.h"
 #include "message-bus.h"
 #include <fty/rest/component.h>
-#include <fty_log.h>
 
 namespace fty {
 
@@ -35,16 +34,14 @@ unsigned AssetRest::run()
 
     commands::assets::In param;
     if (auto res = pack::json::deserialize(m_request.body(), param); !res) {
-        logError("Request document has invalid syntax. {}", res.error());
-        throw rest::errors::BadRequestDocument("Asset creation failed, for more information see log"_tr);
+        throw rest::errors::BadRequestDocument(res.error());
     }
 
     if (auto asset = assets(param)) {
         m_reply << *asset << "\n\n";
         return HTTP_OK;
     } else {
-        logError("Internal Server Error. {}", asset.error());
-        throw rest::errors::Internal("Asset creation failed, for more information see log"_tr);
+        throw rest::errors::Internal(asset.error());
     }
 }
 

--- a/rest/src/mibs.cpp
+++ b/rest/src/mibs.cpp
@@ -36,16 +36,14 @@ unsigned Mibs::run()
 
     commands::mibs::In param;
     if (auto res = pack::json::deserialize(m_request.body(), param); !res) {
-        logError("Request document has invalid syntax. {}", res.error());
-        throw rest::errors::BadRequestDocument("Mibs request failed, for more information see log"_tr);
+        throw rest::errors::BadRequestDocument(res.error());
     }
 
     if (auto list = mibs(param)) {
         m_reply << *list << "\n\n";
         return HTTP_OK;
     } else {
-        logError("Internal Server Error. {}", list.error());
-        throw rest::errors::Internal("Mibs request failed, for more information see log"_tr);
+        throw rest::errors::Internal(list.error());
     }
 }
 

--- a/rest/src/protocols.cpp
+++ b/rest/src/protocols.cpp
@@ -24,7 +24,6 @@
 #include "message-bus.h"
 #include <fty/rest/component.h>
 #include <tnt/http.h>
-#include <fty_log.h>
 
 namespace fty {
 
@@ -37,16 +36,14 @@ unsigned Protocols::run()
 
     commands::protocols::In param;
     if (auto res = pack::json::deserialize(m_request.body(), param); !res) {
-        logError("Request document has invalid syntax. {}", res.error());
-        throw rest::errors::BadRequestDocument("Protocols request failed, for more information see log"_tr);
+        throw rest::errors::BadRequestDocument(res.error());
     }
 
     if (auto list = protocols(param)) {
         m_reply << *list << "\n\n";
         return HTTP_OK;
     } else {
-        logError("Internal Server Error. {}", list.error());
-        throw rest::errors::Internal("Protocols request failed, for more information see log"_tr);
+        throw rest::errors::Internal(list.error());
     }
 }
 


### PR DESCRIPTION
Reverts 42ity/fty-discovery-ng#39

As per Team decision, it's better to have non translated info that are more accurate