### PR TITLE
Fix request timeout

### DIFF
--- a/common/message-bus.h
+++ b/common/message-bus.h
@@ -48,7 +48,7 @@ public:
 
     [[nodiscard]] Expected<void> init(const std::string& actorName);
 
-    [[nodiscard]] Expected<Message> send(const std::string& queue, const Message& msg, int timeoutSec = 10);
+    [[nodiscard]] Expected<Message> send(const std::string& queue, const Message& msg, int timeoutSec = 60);
     [[nodiscard]] Expected<void>    reply(const std::string& queue, const Message& req, const Message& answ);
     [[nodiscard]] Expected<Message> recieve(const std::string& queue);
 


### PR DESCRIPTION
10 seconds timeout has caused issues with native protocol discovery for ATS, changing it to 60 seconds to match UI timeout