### PR TITLE
IPMPROG-2834 /api/v1/discovery/protocols 

### DIFF
--- a/common/commands.h
+++ b/common/commands.h
@@ -25,13 +25,58 @@ namespace commands::protocols {
     class Return: public pack::Node
     {
     public:
-        pack::String protocol  = FIELD("protocol");
-        pack::UInt32 port      = FIELD("port");
-        pack::Bool reachable   = FIELD("reachable");
-        pack::String available = FIELD("available"); // enum ["yes", "no", "maybe"]
+        enum class Available
+        {
+            Unknown, // unknown if protocol is available/not available
+            No,      // protocol is not available
+            Maybe,   // don't know if protocol is available/not available
+            Yes      // protocol is available
+        };
+
+        pack::String          protocol  = FIELD("protocol");
+        pack::UInt32          port      = FIELD("port");
+        pack::Enum<Available> available = FIELD("available");
+        pack::Bool            reachable = FIELD("reachable");
+
     public:
         using pack::Node::Node;
         META(Return, protocol, port, reachable, available);
+    };
+
+    inline std::ostream& operator<<(std::ostream& ss, Return::Available value)
+    {
+        ss << [&]() {
+            switch (value) {
+                case Return::Available::Unknown:
+                    return "unknown";
+                case Return::Available::No:
+                    return "no";
+                case Return::Available::Maybe:
+                    return "maybe";
+                case Return::Available::Yes:
+                    return "yes";
+            }
+            return "unknown";
+        }();
+        return ss;
+    };
+
+    inline std::istream& operator>>(std::istream& ss, Return::Available& value)
+    {
+        std::string strval;
+        ss >> strval;
+        if (strval == "unknown") {
+            value = Return::Available::Unknown;
+        } else if (strval == "no") {
+            value = Return::Available::No;
+        } else if (strval == "maybe") {
+            value = Return::Available::Maybe;
+        } else if (strval == "yes") {
+            value = Return::Available::Yes;
+        } else {
+            value = Return::Available::Unknown;
+        }
+        return ss;
     };
 
     using Out = pack::ObjectList<Return>;

--- a/common/commands.h
+++ b/common/commands.h
@@ -25,12 +25,13 @@ namespace commands::protocols {
     class Return: public pack::Node
     {
     public:
-        pack::String protocol = FIELD("protocol");
-        pack::UInt32 port     = FIELD("port");
-        pack::Bool reachable  = FIELD("reachable");
+        pack::String protocol  = FIELD("protocol");
+        pack::UInt32 port      = FIELD("port");
+        pack::Bool reachable   = FIELD("reachable");
+        pack::String available = FIELD("available"); // enum ["yes", "no", "maybe"]
     public:
         using pack::Node::Node;
-        META(Return, protocol, port, reachable);
+        META(Return, protocol, port, reachable, available);
     };
 
     using Out = pack::ObjectList<Return>;

--- a/server/src/jobs/protocols.cpp
+++ b/server/src/jobs/protocols.cpp
@@ -92,11 +92,13 @@ void Protocols::run(const commands::protocols::In& in, commands::protocols::Out&
     };
 
     for (auto& aux : tries) {
+        using namespace commands::protocols;
+
         auto& protocol = out.append();
         protocol.protocol = aux.protocolStr;
         protocol.port = aux.port;
         protocol.reachable = false; // default, port is not reachable
-        protocol.available = "no"; // and protocol is not available
+        protocol.available = Return::Available::No; // and protocol is not available
 
         // try to reach server
         switch (aux.protocol) {
@@ -104,7 +106,7 @@ void Protocols::run(const commands::protocols::In& in, commands::protocols::Out&
                 if (auto res = tryPowercom(in, aux.port)) {
                     logInfo("Found Powercom device on port {}", aux.port);
                     protocol.reachable = true; // port is reachable
-                    protocol.available = "yes"; // and protocol is available
+                    protocol.available = Return::Available::Yes; // and protocol is available
                 }
                 else {
                     logInfo("Skipped GenApi/{}, reason: {}", aux.port, res.error());
@@ -115,7 +117,7 @@ void Protocols::run(const commands::protocols::In& in, commands::protocols::Out&
                 if (auto res = tryXmlPdc(in, aux.port)) {
                     logInfo("Found XML device on port {}", aux.port);
                     protocol.reachable = true; // port is reachable
-                    protocol.available = "yes"; // and protocol is available
+                    protocol.available = Return::Available::Yes; // and protocol is available
                 }
                 else {
                     logInfo("Skipped xml_pdc/{}, reason: {}", aux.port, res.error());
@@ -126,7 +128,7 @@ void Protocols::run(const commands::protocols::In& in, commands::protocols::Out&
                 if (auto res = trySnmp(in, aux.port)) {
                     logInfo("Found SNMP device on port {}", aux.port);
                     protocol.reachable = true; // port is reachable
-                    protocol.available = "maybe"; // but we don't know if protocol is available
+                    protocol.available = Return::Available::Maybe; // but we don't know if protocol is available
                 }
                 else {
                     logInfo("Skipped SNMP/{}, reason: {}", aux.port, res.error());


### PR DESCRIPTION
add 'available' property to the GET /api/v1/discovery/protocols response payload

* manual compatibility backport (2.5.0) from featureimage/IPMPROG-1244-discovery-migration (2.6.0)
Signed-off-by: Degott, Francois Regis <FrancoisRegisDegott@eaton.com>